### PR TITLE
Sims 4: Use proper random call in create_items

### DIFF
--- a/worlds/sims4/__init__.py
+++ b/worlds/sims4/__init__.py
@@ -66,7 +66,7 @@ class Sims4World(World):
 
         count_to_fill = count_to_fill - len(pool)
 
-        for item_name in self.multiworld.random.choices(sorted(filler_set), k=count_to_fill):
+        for item_name in self.random.choices(sorted(filler_set), k=count_to_fill):
             item = self.create_item(item_name)
             item.classification = item.classification
             pool.append(item)


### PR DESCRIPTION
changes create_items to use self.random instead of self.multiworld.random